### PR TITLE
Remove leading space from keywords.txt identifier token

### DIFF
--- a/Timers/keywords.txt
+++ b/Timers/keywords.txt
@@ -6,18 +6,18 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Timers	 KEYWORD1
+Timers	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-update	 KEYWORD2
-addTimer	 KEYWORD2
-removeTimer	 KEYWORD2
-enableTimer	 KEYWORD2
-disableTimer	 KEYWORD2
-changePeriod	 KEYWORD2
+update	KEYWORD2
+addTimer	KEYWORD2
+removeTimer	KEYWORD2
+enableTimer	KEYWORD2
+disableTimer	KEYWORD2
+changePeriod	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
@@ -27,5 +27,5 @@ changePeriod	 KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-MILLI	 LITERAL1
-MICRO	 LITERAL1
+MILLI	LITERAL1
+MICRO	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. Leading spaces on a keyword identifier causes it to not be recognized by the Arduino IDE. On Arduino IDE 1.6.5 and newer an unrecognized keyword identifier causes the default editor.function.style highlighting to be used (as with KEYWORD2, KEYWORD3).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords